### PR TITLE
Mark messages as read after viewing

### DIFF
--- a/src/bitmsg/BitMsgComms.java
+++ b/src/bitmsg/BitMsgComms.java
@@ -284,5 +284,14 @@ public class BitMsgComms
 		return getSentMessageByAckData(ackData);
 		
 	}
+	
+	public void setRead(String msg_id, int read) throws MalformedURLException, XmlRpcException
+	{
+		Vector<String> params = new Vector<String>();
+		params.addElement(msg_id);
+		params.addElement(Integer.toString(read));
+		
+		getBitMsg().execute("setRead", params);
+	}
 
 }

--- a/src/www/WebServerConnection.java
+++ b/src/www/WebServerConnection.java
@@ -313,6 +313,7 @@ public class WebServerConnection extends Thread
 				
 				out.println(output);
 				
+				bitMsgComms.setRead(msg.getId(), 1);
 			}
 			else if (requestParts[1].startsWith("/sent/message/"))
 			{


### PR DESCRIPTION
Dependant on https://github.com/Bitmessage/PyBitmessage/pull/368 being pulled to master.

Marks inbox messages as read after they have been viewed. Fixes #21.
